### PR TITLE
Dockerfile: install mgltools to `/usr/local/lib/`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,16 @@ RUN conda config --add channels  https://conda.anaconda.org/rdkit && \
                      nomkl \
                      rdkit
 
+RUN curl --location http://mgltools.scripps.edu/downloads/downloads/tars/releases/REL1.5.6/mgltools_x86_64Linux2_1.5.6.tar.gz > mgltools.tar.gz && \
+tar vxzf mgltools.tar.gz && \                                                                       
+rm mgltools.tar.gz && \                                                                             
+mv mgltools_x86_64Linux2_1.5.6 /usr/local/lib/ && \                                                  
+cd /usr/local/lib/mgltools_x86_64Linux2_1.5.6 && \                                                  
+./install.sh                                                                                        
+                                                                                                    
+ENV PATH="${PATH}:/usr/local/lib/mgltools_x86_64Linux2_1.5.6/bin" 
+
+
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work
 RUN chmod -R a+rw /kb/module


### PR DESCRIPTION
`mgltools` is a standalone ~python2.4 library so make sure to run `./install.sh` when mgltools is in its intended directory, otherwise the python `sys.path` will be screwed up and relative to wherever `install.sh` was run. I've already done it correctly in the Dockerfile.

I added `/usr/local/lib/mgltools_x86_64Linux2_1.5.6/bin` to path, where the executables `python2.5` and `pythonsh` are. Ada uses `pythonsh`, but I find that this turns out to be python3 for me, so I use `python2.5`, e.g., `"python2.5 /usr/local/lib/mgltools_x86_64Linux2_1.5.6/MGLToolsPckgs/AutoDockTools/Utilities24/prepare_ligand4.py blah blah blah"`

So doing that, you can easily replace obabel!